### PR TITLE
fix(typing-indicator): display typing indicator in correct position on mobile

### DIFF
--- a/src/components/_typing.sass
+++ b/src/components/_typing.sass
@@ -1,9 +1,15 @@
+/* Positioning for typing indicator */
+.cSZYKt {
+  position: relative;
+}
+
 /* Adds Discord typing indicator animation */
 .sc-dacGJm {
   position: absolute;
   background-color: transparent;
   width: 100%;
-  top: 100vh;
+  bottom: 0;
+  left: 0;
 
   * {
     background-color: transparent !important;


### PR DESCRIPTION
Fixes the typing indicator going off screen. Desktop compatibility is maintained.