### PR TITLE
feat(server indicators): discord-style mention indicators

### DIFF
--- a/src/components/_server.sass
+++ b/src/components/_server.sass
@@ -25,6 +25,18 @@
 }
 .sc-jeGTLq circle {
   display: none;
+
+  /* Pings */
+  &[fill="var(--error)"] {
+    display: block;
+    cy: 30px;
+    r: 6px;
+
+    & + text {
+      font-weight: 600;
+      transform: translateY(27px);
+    }
+  }
 }
 
 /* server has unread message(s) */

--- a/src/components/_server.sass
+++ b/src/components/_server.sass
@@ -29,12 +29,15 @@
   /* Pings */
   &[fill="var(--error)"] {
     display: block;
-    cy: 30px;
-    r: 6px;
+    cx: 26px;
+    cy: 26px;
+    r: 7px;
+    stroke: var(--background);
+    stroke-width: 3px;
 
     & + text {
       font-weight: 600;
-      transform: translateY(27px);
+      transform: translate(-1px, 23px);
     }
   }
 }


### PR DESCRIPTION
- red background to pings on servers (undoes `display: none` on `circle` elements that are for mention indicators)
- position indicator in bottom-right corner of icon
- center text within circle
- "cutout" style by creating an outline to the indicator using the background colour